### PR TITLE
(hot-fix) diary api 에서 답변 조회 시 정렬 문제 해결

### DIFF
--- a/src/backend/answers/answers.controller.ts
+++ b/src/backend/answers/answers.controller.ts
@@ -154,7 +154,7 @@ export class AnswersController {
   @ApiQuery({
     name: 'direction',
     required: false,
-    description: 'direction',
+    description: 'direction (0: get older diaries, 1: get new diaries)',
   })
   @Get('diary')
   async diary(
@@ -165,7 +165,7 @@ export class AnswersController {
   ): Promise<DiaryAnswersDto> {
     try {
       const date = dateString ? getDateString({ date: dateString }) : null;
-      const answers = date
+      let answers = date
         ? await this.answersService.getAnswersDiaryByDate({
           userId,
           date,
@@ -173,6 +173,20 @@ export class AnswersController {
           direction,
         })
         : await await this.answersService.getAnswersDiary({ userId, limit });
+      
+      if (date && direction === 0) {
+        // 날짜 오름차순으로 재 정렬
+        answers = answers.sort((answer, compareAnswer) => {
+          const answerDate = answer.date
+          const compareAnswerDate = compareAnswer.date
+
+          if (answerDate < compareAnswerDate) {
+            return -1;
+          }
+
+          return 1;
+        });
+      }
       return { data: { date, limit, direction, answers } };
     } catch (error) {
       throw new CustomInternalServerErrorException(error.message);

--- a/src/backend/answers/answers.controller.ts
+++ b/src/backend/answers/answers.controller.ts
@@ -177,9 +177,7 @@ export class AnswersController {
       if (date && direction === 0) {
         // 날짜 오름차순으로 재 정렬
         answers = answers.sort((answer, compareAnswer) => {
-          const answerDate = new Date(answer.date);
-          const compareAnswerDate = new Date(compareAnswer.date);
-          return answerDate.getTime() - compareAnswerDate.getTime();
+          return answer.date > compareAnswer.date ? 1 : -1
         });
       }
       return { data: { date, limit, direction, answers } };

--- a/src/backend/answers/answers.controller.ts
+++ b/src/backend/answers/answers.controller.ts
@@ -177,14 +177,9 @@ export class AnswersController {
       if (date && direction === 0) {
         // 날짜 오름차순으로 재 정렬
         answers = answers.sort((answer, compareAnswer) => {
-          const answerDate = answer.date
-          const compareAnswerDate = compareAnswer.date
-
-          if (answerDate < compareAnswerDate) {
-            return -1;
-          }
-
-          return 1;
+          const answerDate = new Date(answer.date);
+          const compareAnswerDate = new Date(compareAnswer.date);
+          return answerDate.getTime() - compareAnswerDate.getTime();
         });
       }
       return { data: { date, limit, direction, answers } };

--- a/src/backend/answers/answers.service.ts
+++ b/src/backend/answers/answers.service.ts
@@ -106,6 +106,7 @@ export class AnswersService {
     direction: number;
   }): Promise<Answer[]> {
     const whereDate = direction === 0 ? LessThan(date) : MoreThan(date);
+    const orderById = direction === 0 ? "DESC" : "ASC";
     return this.answersRepository.find({
       where: {
         date: whereDate,
@@ -113,7 +114,7 @@ export class AnswersService {
       },
       take: limit,
       order: {
-        id: -1,
+        id: orderById,
       },
       relations,
     });


### PR DESCRIPTION
날짜를 기준으로 N 개를 가져온 다음 정렬하는 게 아니라, 정렬한 다음 N 개를 가져오기에
최근 답변 조회 시 해당 날짜 주변이 아닌, 가장 최근 답변이 조회되는 문제가 있어 이슈를 수정했습니다.

오래된 답변의 경우 날짜를 내림차순으로 정렬하고, 최근 답변의 경우 오름차순으로 정렬한 다음 N 개를 가져옵니다.
오래된 답변을 반환할 때 다시 오름차순으로 sort 한 다음 반환합니다.